### PR TITLE
Issue 25: ENTER key when no controlled character.

### DIFF
--- a/src/bombsite/modules/gameplay.py
+++ b/src/bombsite/modules/gameplay.py
@@ -83,8 +83,8 @@ class GamePlay(Module):
             return ModuleComponent(ModuleEnum.MAIN_MENU, screen=self.display.screen)
 
         elif event.type == pygame.KEYDOWN and event.key == pygame.K_RETURN:
-            character = self.playing_field.controlled_character
-            if character.details.team.ai is None:
+            character = self.playing_field.controlled_character_or_none
+            if character and character.details.team.ai is None:
                 character.start_attack()
 
         return None


### PR DESCRIPTION
There was a bug when the ENTER key was pressed without there being a controlled character. This is solved now.

Issue: https://github.com/clockback/bombsite/issues/25