### PR TITLE
Issue 31: Update README for Ruff usage.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,8 @@ The following commands should be used to ensure that the code is acceptable:
 
 .. code-block:: sh
 
-   $ python -m pylint --rcfile=.settings/pylintrc src/
+   $ python -m ruff check src/
+   $ python -m ruff format --check src/
    $ python -m mypy src/
 
 These checks must pass before being integrated into the master branch.


### PR DESCRIPTION
This was missed in the previous pull request. The README should indicate what should be done in the development process. Ruff compliance is required for code acceptability.

Issue: https://github.com/clockback/bombsite/issues/31