### PR TITLE
Issue 41: Remove typing_extensions.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 authors = [{name = "Elliot Simpson", email = "elliot@p-s.co.nz"}]
 description = "Worms clone"
 requires-python = ">=3.11"
-dependencies = ["pygame==2.5.2", "numpy", "typing_extensions==4.8.0"]
+dependencies = ["pygame==2.5.2", "numpy"]
 
 [project.scripts]
 bombsite = "bombsite.bombsite:main"


### PR DESCRIPTION
The typing_extensions dependency is unused, and should not be included in the project.

Issue: https://github.com/clockback/bombsite/issues/41