### PR TITLE
Issue 46: Add virtual environment to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ debian/bombsite.substvars
 debian/debhelper-build-stamp
 debian/files
 debian/*.debhelper
+.venv


### PR DESCRIPTION
The virtual environment ought to be contained in `.gitignore`.

Pull request: https://github.com/clockback/bombsite/issues/46